### PR TITLE
refactor: Deprecate the "update" aspect of context hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,27 +105,7 @@ from copier_templates_extensions import ContextHook
 
 class ContextUpdater(ContextHook):
     def hook(self, context):
-        new_context = {}
-        new_context["say"] = "hello " + context["name"]
-        return new_context
-```
-
-Using the above example, your context will be updated
-with the `new_context` returned by the method.
-If you prefer to modify the context in-place instead,
-for example to *remove* items from it,
-set the `update` class attribute to `False`:
-
-```python
-from copier_templates_extensions import ContextHook
-
-
-class ContextUpdater(ContextHook):
-    update = False
-
-    def hook(self, context):
         context["say"] = "hello " + context["name"]
-        del context["name"]
 ```
 
 In your Jinja templates, you will now have access
@@ -197,7 +177,7 @@ from copier_templates_extensions import ContextHook
 
 class ContextUpdater(ContextHook):
     def hook(self, context):
-        return {"module_name": "app" if context["project_type"] == "webapi" else "cli"}
+        context["module_name"] = "app" if context["project_type"] == "webapi" else "cli"
 ```
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "copier>=6",
+    "copier>=9.2",
 ]
 
 [project.urls]

--- a/src/copier_templates_extensions/extensions/loader.py
+++ b/src/copier_templates_extensions/extensions/loader.py
@@ -31,7 +31,7 @@ class TemplateExtensionLoader(Extension):
     def _patched_import_string(self, import_name: str, *, silent: bool = False) -> Any:
         try:
             return self._import_string(import_name)
-        except Exception:  # noqa: BLE001
+        except Exception:
             if not silent:
                 raise
 

--- a/tests/fixtures/deprecation_warning_hook_return/copier.yml
+++ b/tests/fixtures/deprecation_warning_hook_return/copier.yml
@@ -1,0 +1,3 @@
+_jinja_extensions:
+- copier_templates_extensions.TemplateExtensionLoader
+- extensions.py:ContextUpdater

--- a/tests/fixtures/deprecation_warning_hook_return/extensions.py
+++ b/tests/fixtures/deprecation_warning_hook_return/extensions.py
@@ -1,0 +1,6 @@
+from copier_templates_extensions import ContextHook
+
+
+class ContextUpdater(ContextHook):
+    def hook(self, context):
+        return {"success": True}

--- a/tests/fixtures/deprecation_warning_hook_return/result.txt.jinja
+++ b/tests/fixtures/deprecation_warning_hook_return/result.txt.jinja
@@ -1,0 +1,1 @@
+Success variable: {{ success|default("not set") }}

--- a/tests/fixtures/deprecation_warning_update_attr/copier.yml
+++ b/tests/fixtures/deprecation_warning_update_attr/copier.yml
@@ -1,0 +1,3 @@
+_jinja_extensions:
+- copier_templates_extensions.TemplateExtensionLoader
+- extensions.py:ContextUpdater

--- a/tests/fixtures/deprecation_warning_update_attr/extensions.py
+++ b/tests/fixtures/deprecation_warning_update_attr/extensions.py
@@ -1,0 +1,8 @@
+from copier_templates_extensions import ContextHook
+
+
+class ContextUpdater(ContextHook):
+    update = "not sentinel"
+
+    def hook(self, context):
+        context["success"] = True

--- a/tests/fixtures/deprecation_warning_update_attr/result.txt.jinja
+++ b/tests/fixtures/deprecation_warning_update_attr/result.txt.jinja
@@ -1,0 +1,1 @@
+Success variable: {{ success|default("not set") }}

--- a/tests/fixtures/modifying_context/extensions.py
+++ b/tests/fixtures/modifying_context/extensions.py
@@ -2,7 +2,5 @@ from copier_templates_extensions import ContextHook
 
 
 class ContextUpdater(ContextHook):
-    update = False
-
     def hook(self, context):
         context["success"] = True

--- a/tests/fixtures/not_updating_context_for_prompts/extensions.py
+++ b/tests/fixtures/not_updating_context_for_prompts/extensions.py
@@ -3,4 +3,4 @@ from copier_templates_extensions import ContextHook
 
 class ContextUpdater(ContextHook):
     def hook(self, context):
-        return {"success": True}
+        context["success"] = True

--- a/tests/fixtures/updating_context/extensions.py
+++ b/tests/fixtures/updating_context/extensions.py
@@ -3,4 +3,4 @@ from copier_templates_extensions import ContextHook
 
 class ContextUpdater(ContextHook):
     def hook(self, context):
-        return {"success": True}
+        context["success"] = True

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -58,3 +58,22 @@ def test_extensions_raising_exceptions(tmp_path: Path, template_name: str, excep
         copier.run_copy(str(template_path), tmp_path, defaults=True, overwrite=True, unsafe=True)
     assert not (tmp_path / "result.txt").exists()
     assert not (tmp_path / "extensions.py").exists()
+
+
+@pytest.mark.parametrize(
+    "template_name",
+    ["deprecation_warning_hook_return", "deprecation_warning_update_attr"],
+)
+def test_deprecated_usage(tmp_path: Path, template_name: str) -> None:
+    """Test deprecation warnings.
+
+    Arguments:
+        tmp_path: A pytest fixture.
+        template_name: The parametrized template to use.
+    """
+    template_path = TEMPLATES_DIRECTORY / template_name
+    with pytest.warns(DeprecationWarning):
+        copier.run_copy(str(template_path), tmp_path, defaults=True, overwrite=True, unsafe=True)
+    result_file = tmp_path / "result.txt"
+    assert result_file.exists()
+    assert result_file.read_text() == "Success variable: True"


### PR DESCRIPTION
Context hooks must now always modify the context in place. The API is deprecated accordingly (backward compatible).

Issue-4: https://github.com/copier-org/copier-templates-extensions/issues/4