### PR TITLE
Use phase from Copier 9.5 to execute context hook only when rendering files

### DIFF
--- a/config/pytest.ini
+++ b/config/pytest.ini
@@ -12,3 +12,4 @@ filterwarnings =
   error
   # TODO: remove once pytest-xdist 4 is released
   ignore:.*rsyncdir:DeprecationWarning:xdist
+  ignore:.*:ResourceWarning:plumbum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "copier>=9.5",
+    "copier>=9.4",
+    # "copier>=9.5",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "copier>=9.2",
+    "copier>=9.5",
 ]
 
 [project.urls]

--- a/src/copier_templates_extensions/extensions/context.py
+++ b/src/copier_templates_extensions/extensions/context.py
@@ -46,10 +46,10 @@ class ContextHook(Extension):
                         stacklevel=1,
                     )
 
-                if (
-                    parent["_copier_conf"]["_phase"] == "render"
-                    and (context := extension_self.hook(parent)) is not None  # type: ignore[attr-defined]
-                ):
+                # if "_copier_conf" not in parent or parent["_copier_conf"]["phase"].value != "render":
+                #     return
+
+                if "_copier_conf" in parent and (context := extension_self.hook(parent)) is not None:  # type: ignore[attr-defined]
                     parent.update(context)
                     warnings.warn(
                         "Returning a dict from the `hook` method is deprecated. "

--- a/src/copier_templates_extensions/extensions/context.py
+++ b/src/copier_templates_extensions/extensions/context.py
@@ -45,7 +45,11 @@ class ContextHook(Extension):
                         DeprecationWarning,
                         stacklevel=1,
                     )
-                if "_copier_conf" in parent and (context := extension_self.hook(parent)) is not None:  # type: ignore[attr-defined]
+
+                if (
+                    parent["_copier_conf"]["_phase"] == "render"
+                    and (context := extension_self.hook(parent)) is not None  # type: ignore[attr-defined]
+                ):
                     parent.update(context)
                     warnings.warn(
                         "Returning a dict from the `hook` method is deprecated. "

--- a/tests/fixtures/update_project/copier.yml
+++ b/tests/fixtures/update_project/copier.yml
@@ -1,0 +1,6 @@
+_jinja_extensions:
+- copier_templates_extensions.TemplateExtensionLoader
+- extensions.py:ContextUpdater
+
+the_question:
+  type: str

--- a/tests/fixtures/update_project/extensions.py
+++ b/tests/fixtures/update_project/extensions.py
@@ -1,0 +1,6 @@
+from copier_templates_extensions import ContextHook
+
+
+class ContextUpdater(ContextHook):
+    def hook(self, context):
+        context["success"] = bool(context["the_question"])

--- a/tests/fixtures/update_project/result.txt.jinja
+++ b/tests/fixtures/update_project/result.txt.jinja
@@ -1,0 +1,1 @@
+Success variable: {{ success|default("not set") }}

--- a/tests/fixtures/update_project/{{_copier_conf.answers_file}}.jinja
+++ b/tests/fixtures/update_project/{{_copier_conf.answers_file}}.jinja
@@ -1,0 +1,1 @@
+{{_copier_answers|to_nice_yaml}}

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -114,4 +114,4 @@ def test_update(tmp_path_factory: pytest.TempPathFactory) -> None:
     git("-C", dest_path, "commit", "-m", "Initial commit")
     git("-C", dest_path, "tag", "1.0.0")
 
-    copier.run_update(dest_path, unsafe=True, overwrite=True, data={"the_question": "the_answer2"})
+    copier.run_update(dest_path, unsafe=True, overwrite=True)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -19,7 +19,14 @@ def git(*args: str | Path) -> None:
     Arguments:
         *args: The git command to run.
     """
-    subprocess.run(["git", *args], check=True)  # noqa: S603,S607
+    subprocess.run(  # noqa: S603
+        ["git", *args],  # noqa: S607
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "Copier Test",
+            "GIT_AUTHOR_EMAIL": "copier@test",
+        },
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -19,7 +19,7 @@ def git(*args: str | Path) -> None:
     Arguments:
         *args: The git command to run.
     """
-    subprocess.run(["git", *args], check=True)
+    subprocess.run(["git", *args], check=True)  # noqa: S603,S607
 
 
 @pytest.mark.parametrize(
@@ -108,7 +108,14 @@ def test_update(tmp_path_factory: pytest.TempPathFactory) -> None:
     git("-C", src_path, "commit", "-m", "Initial commit")
     git("-C", src_path, "tag", "0.1.0")
 
-    copier.run_copy(str(src_path), dest_path, unsafe=True, overwrite=True, defaults=True, data={"the_question": "the_answer"})
+    copier.run_copy(
+        str(src_path),
+        dest_path,
+        unsafe=True,
+        overwrite=True,
+        defaults=True,
+        data={"the_question": "the_answer"},
+    )
     git("-C", dest_path, "init")
     git("-C", dest_path, "add", "-A", ".")
     git("-C", dest_path, "commit", "-m", "Initial commit")

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -25,6 +25,8 @@ def git(*args: str | Path) -> None:
         env={
             "GIT_AUTHOR_NAME": "Copier Test",
             "GIT_AUTHOR_EMAIL": "copier@test",
+            "GIT_COMMITTER_NAME": "Copier Test",
+            "GIT_COMMITTER_EMAIL": "copier@test",
         },
     )
 


### PR DESCRIPTION
Fixes #7. Needs https://github.com/copier-org/copier/pull/1948.