### PR TITLE
tests: Add test for accessing answer in context hook

### DIFF
--- a/tests/fixtures/answer_access/copier.yml
+++ b/tests/fixtures/answer_access/copier.yml
@@ -1,0 +1,3 @@
+_jinja_extensions:
+- copier_templates_extensions.TemplateExtensionLoader
+- extensions.py:ContextUpdater

--- a/tests/fixtures/answer_access/extensions.py
+++ b/tests/fixtures/answer_access/extensions.py
@@ -1,0 +1,6 @@
+from copier_templates_extensions import ContextHook
+
+
+class ContextUpdater(ContextHook):
+    def hook(self, context):
+        context["success"] = context["foo"] == "bar"

--- a/tests/fixtures/answer_access/result.txt.jinja
+++ b/tests/fixtures/answer_access/result.txt.jinja
@@ -1,0 +1,1 @@
+Success variable: {{ success }}

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -77,3 +77,16 @@ def test_deprecated_usage(tmp_path: Path, template_name: str) -> None:
     result_file = tmp_path / "result.txt"
     assert result_file.exists()
     assert result_file.read_text() == "Success variable: True"
+
+
+def test_answer_access(tmp_path: Path) -> None:
+    """Test accessing an answer.
+
+    Arguments:
+        tmp_path: A pytest fixture.
+    """
+    template_path = TEMPLATES_DIRECTORY / "answer_access"
+    copier.run_copy(str(template_path), tmp_path, data={"foo": "bar"}, defaults=True, overwrite=True, unsafe=True)
+    result_file = tmp_path / "result.txt"
+    assert result_file.exists()
+    assert result_file.read_text() == "Success variable: True"


### PR DESCRIPTION
This is a regression test for https://github.com/copier-org/copier/issues/1977. It should pass once https://github.com/copier-org/copier/pull/1993 gets released.