### PR TITLE
fix(loader): add loaded module to `sys.modules`

### DIFF
--- a/src/copier_templates_extensions/extensions/loader.py
+++ b/src/copier_templates_extensions/extensions/loader.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
-import sys
 from typing import TYPE_CHECKING, Any
 
 from copier.errors import UserMessageError

--- a/src/copier_templates_extensions/extensions/loader.py
+++ b/src/copier_templates_extensions/extensions/loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+import sys
 from typing import TYPE_CHECKING, Any
 
 from copier.errors import UserMessageError
@@ -80,9 +81,10 @@ class TemplateExtensionLoader(Extension):
                 "Please report this issue to the template maintainers.",
             )
         spec = spec_from_file_location(
-            f"copier_templates_extensions.{module_name}",
+            module_full_name := f"copier_templates_extensions.{module_name}",
             template_relative_path,
         )
         module = module_from_spec(spec)  # type: ignore[arg-type]
+        sys.modules[module_full_name] = module
         spec.loader.exec_module(module)  # type: ignore[union-attr]
         return module

--- a/tests/fixtures/dataclass/copier.yml
+++ b/tests/fixtures/dataclass/copier.yml
@@ -1,0 +1,4 @@
+_subdirectory: template
+_jinja_extensions:
+  - copier_templates_extensions.TemplateExtensionLoader
+  - extensions/ctx.py:Success

--- a/tests/fixtures/dataclass/extensions/ctx.py
+++ b/tests/fixtures/dataclass/extensions/ctx.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from jinja2.ext import Extension
+
+@dataclass
+class Test:
+    key: str
+    value: str
+
+class Success(Extension):
+    def __init__(self, environment):
+        super().__init__(environment)
+        environment.globals.update(success=True)

--- a/tests/fixtures/dataclass/template/result.txt.jinja
+++ b/tests/fixtures/dataclass/template/result.txt.jinja
@@ -1,0 +1,1 @@
+Success variable: {{ success|default("not set") }}

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -18,6 +18,7 @@ TEMPLATES_DIRECTORY = Path(__file__).parent / "fixtures"
         ("modifying_context", "True"),
         ("not_updating_context_for_prompts", "True"),
         ("loading_normal_extension", "not set"),
+        ("dataclass", "True"),
     ],
 )
 def test_extensions(tmp_path: Path, template_name: str, expected: str) -> None:


### PR DESCRIPTION
Add a weird case that I had, similar to https://github.com/mkdocs/mkdocs/issues/3141

If an extension uses `@dataclass` in a module nested in a package (I did not manage to reproduce this case with a root module), it fails to load the module if it's not exposed in `sys.modules`.

This PR fixes it