### PR TITLE
chore: Fix return type in type annotation

### DIFF
--- a/src/copier_templates_extensions/_internal/context.py
+++ b/src/copier_templates_extensions/_internal/context.py
@@ -58,7 +58,7 @@ class ContextHook(Extension):
 
         environment.context_class = ContextClass
 
-    def hook(self, context: dict) -> dict:
+    def hook(self, context: dict[str, Any]) -> dict[str, Any] | None:
         """Abstract hook. Does nothing.
 
         Override this method to either return


### PR DESCRIPTION
mypy complains that I don't return a dictionary from the method.