### PR TITLE
refactor: Expose old paths to ease migration

### DIFF
--- a/src/copier_templates_extensions/__init__.py
+++ b/src/copier_templates_extensions/__init__.py
@@ -9,7 +9,7 @@ from copier_template_extensions import ContextHook, TemplateExtensionLoader
 __all__: list[str] = ["ContextHook", "TemplateExtensionLoader"]
 
 warnings.warn(
-    "The `copier-templates-extensions` is renamed `copier-template-extensions`. "
+    "`copier-templates-extensions` is renamed `copier-template-extensions`. "
     "Please use the new name, and replace every occurrence of "
     "`copier-templates-extensions` and `copier_templates_extensions` in your template with "
     "`copier-template-extensions` and `copier_template_extensions` respectively.",

--- a/src/copier_templates_extensions/__init__.py
+++ b/src/copier_templates_extensions/__init__.py
@@ -1,0 +1,18 @@
+"""Deprecated. Import from `copier-template-extensions` instead."""
+
+# YORE: Bump 1: Remove file.
+
+import warnings
+
+from copier_template_extensions import ContextHook, TemplateExtensionLoader
+
+__all__: list[str] = ["ContextHook", "TemplateExtensionLoader"]
+
+warnings.warn(
+    "The `copier-templates-extensions` is renamed `copier-template-extensions`. "
+    "Please use the new name, and replace every occurrence of "
+    "`copier-templates-extensions` and `copier_templates_extensions` in your template with "
+    "`copier-template-extensions` and `copier_template_extensions` respectively.",
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
Just trying to make things the easiest possible for template writers and users.

With this change, installing `copier-template-extensions` will provide both `copier_template_extensions` and `copier_templates_extensions` packages. This way projects can be updated from template versions using old name to versions using new name, with either the old distribution installed, or the new distribution installed, or both installed (no need to install both anymore).